### PR TITLE
TLPORTAL-161: change denied access to forbidden rather than unauthorized

### DIFF
--- a/server/courselist.rb
+++ b/server/courselist.rb
@@ -392,7 +392,7 @@ END
     ## Make sure people only ask about themselves (or are privileged)
     vetoResult = CourseList.vetoRequest request.env['REMOTE_USER'], request.env['REQUEST_URI']
     logger.debug "vetoResult: "+vetoResult.to_s
-    halt 401 if vetoResult == true
+    halt 403 if vetoResult == true
   end
 
   ########### URL ROUTERS ##############


### PR DESCRIPTION
Change return status for access to other peoples data from 401 (unauthorized) to 403 (forbidden).

Due date: 2/11/15 (but earlier would be good).

Reviewers: 
@zqian @lsloan 