### PR TITLE
Tlportal 230 - Move configuration of system check to security.yml file.

### DIFF
--- a/server/data_provider_file.rb
+++ b/server/data_provider_file.rb
@@ -6,9 +6,16 @@ module DataProviderFile
 ### Return the data for a request from a matching file.  The file will be in the
 ### directory specified.
 ### The name of the file must be <name>.json.  The <name> will be the user name.
-### For testing this need not be a uniqname but can be anyname that maps to a file.
+### For testing this need not be a uniqname but can be any name that maps to a file.
 ### The url localhost:3000/courses/abba.json would map to a file named abba.json in the
 ### specified directory under the default test-files directory.
+
+## Use these values for the Student Dashboard check call.  Use static values since the file provider has
+## no configuration.  There must be a corresponding data file.  The "default" file should always
+## be available.
+
+  @@default_uniqname="default"
+  @@default_term=2010
 
   def dataProviderFileCourse(uniqname, termid, data_provider_file_directory)
     logger.debug "data provider is DataProviderFileCourse.\n"
@@ -35,6 +42,15 @@ module DataProviderFile
 
     return getWrappedDiskFile(data_file)
   end
+
+# The check call will return the results for a request that is done with a single
+# configured user and term.  This allows safely running the check via URL for external monitoring
+# without requiring authentication.
+
+  def dataProviderFileCheck(data_provider_file_directory)
+    return dataProviderFileCourse(@@default_uniqname, @@default_term, data_provider_file_directory)
+  end
+
 
   def getWrappedDiskFile(data_file)
     logger.debug "#{__LINE__}: DPFC: data file string: "+data_file

--- a/server/local/security.yml.TEMPLATE
+++ b/server/local/security.yml.TEMPLATE
@@ -24,6 +24,8 @@
 # key: baseball
 # secret: practice
 # token: optional
+# check_uniqname: ststvii
+# check_termid: 2010
 
 ### WSO2 ties security credentials to "applications" created in it's API directory store.
 ### The application name used here is the one selected for use by this instance of this program.
@@ -34,6 +36,9 @@
 ### The key and secret are supplied when registering an application in the ESB.
 ### The ESB registration process provides a token along with the key and secret.  WAPI knows how to
 ### get / renew this token automatically so it does not need to be explicitly specified.
+
+### The check uniqname and termid are kept here since they may be sensitive and should change with
+### depending on the ESB instance being used.
 
 
 #### END ####

--- a/server/local/studentdashboard-DEV-permissive-file.yml
+++ b/server/local/studentdashboard-DEV-permissive-file.yml
@@ -19,10 +19,6 @@ authn_wait_min: 0.01
 authn_wait_max: 0.03
 # public members of this MCommunity group have administrative privileges on Latte.
 latte_admin_group: TL-Latte-admin-test
-# These values are used to run a check query on the Latte ESB connection.  The uniqname
-# should be a test user.
-check_uniqname: ststvii
-check_termid: 2060
 # set logging level.  Default is INFO.
 use_log_level: DEBUG
 ### end ###

--- a/server/local/studentdashboard-DEV-permissive.yml
+++ b/server/local/studentdashboard-DEV-permissive.yml
@@ -19,10 +19,6 @@ authn_wait_min: 0.01
 authn_wait_max: 0.03
 # public members of this MCommunity group have administrative privileges on Latte.
 latte_admin_group: TL-Latte-admin-test
-# These values are used to run a check query on the Latte ESB connection.  The uniqname
-# should be a test user.
-check_uniqname: ststvii
-check_termid: 2060
 # set logging level.  Default is INFO.
 use_log_level: DEBUG
 ### end ###

--- a/server/local/studentdashboard-DEV-restrictive-file.yml
+++ b/server/local/studentdashboard-DEV-restrictive-file.yml
@@ -19,10 +19,6 @@ authn_wait_min: 0.01
 authn_wait_max: 0.03
 # public members of this MCommunity group have administrative privileges on Latte.
 latte_admin_group: TL-Latte-admin-test
-# These values are used to run a check query on the Latte ESB connection.  The uniqname
-# should be a test user.
-check_uniqname: ststvii
-check_termid: 2060
 # set logging level.  Default is INFO.
 use_log_level: DEBUG
 ### end ###

--- a/server/local/studentdashboard-DEV-restrictive.yml
+++ b/server/local/studentdashboard-DEV-restrictive.yml
@@ -19,10 +19,6 @@ authn_wait_min: 0.01
 authn_wait_max: 0.03
 # public members of this MCommunity group have administrative privileges on Latte.
 latte_admin_group: TL-Latte-admin-test
-# These values are used to run a check query on the Latte ESB connection.  The uniqname
-# should be a test user.
-check_uniqname: ststvii
-check_termid: 2060
 # set logging level.  Default is INFO.
 use_log_level: DEBUG
 ### end ###

--- a/server/local/studentdashboard-DEV.yml
+++ b/server/local/studentdashboard-DEV.yml
@@ -19,10 +19,6 @@ authn_wait_min: 0.01
 authn_wait_max: 0.03
 # public members of this MCommunity group have administrative privileges on Latte.
 latte_admin_group: TL-Latte-admin-test
-# These values are used to run a check query on the Latte ESB connection.  The uniqname
-# should be a test user.
-check_uniqname: ststvii
-check_termid: 2060
 # set logging level.  Default is INFO.
 use_log_level: DEBUG
 ### end ###

--- a/server/local/studentdashboard-LOCALHOST.yml
+++ b/server/local/studentdashboard-LOCALHOST.yml
@@ -19,10 +19,6 @@ authn_wait_min: 0.01
 authn_wait_max: 0.03
 # public members of this MCommunity group have administrative privileges on Latte.
 latte_admin_group: TL-Latte-admin-test
-# These values are used to run a check query on the Latte ESB connection.  The uniqname
-# should be a test user.
-check_uniqname: ststvii
-check_termid: 2060
 # set logging level.  Default is INFO.
 use_log_level: DEBUG
 ### end ###

--- a/server/local/studentdashboard-PROD.yml
+++ b/server/local/studentdashboard-PROD.yml
@@ -19,10 +19,6 @@ authn_wait_min: 0.01
 authn_wait_max: 0.03
 # public members of this MCommunity group have administrative privileges on Latte.
 latte_admin_group: TL-Latte-admin
-# These values are used to run a check query on the Latte ESB connection.  The uniqname
-# should be a test user.
-check_uniqname: ststvii
-check_termid: 2060
 # set logging level.  Default is INFO.
 use_log_level: INFO
 ### end ###

--- a/server/local/studentdashboard-QA-LOAD-TEST.yml
+++ b/server/local/studentdashboard-QA-LOAD-TEST.yml
@@ -19,10 +19,6 @@ authn_wait_min: 0.01
 authn_wait_max: 0.03
 # public members of this MCommunity group have administrative privileges on Latte.
 latte_admin_group: TL-Latte-admin-test
-# These values are used to run a check query on the Latte ESB connection.  The uniqname
-# should be a test user.
-check_uniqname: ststvii
-check_termid: 2060
 # set logging level.  Default is INFO.
 use_log_level: INFO
 ### end ###

--- a/server/local/studentdashboard-QA-PESB.yml
+++ b/server/local/studentdashboard-QA-PESB.yml
@@ -19,10 +19,6 @@ authn_wait_min: 0.01
 authn_wait_max: 0.03
 # public members of this MCommunity group have administrative privileges on Latte.
 latte_admin_group: TL-Latte-admin-test
-# These values are used to run a check query on the Latte ESB connection.  The uniqname
-# should be a test user.
-check_uniqname: ststvii
-check_termid: 2060
 # set logging level.  Default is INFO.
 use_log_level: INFO
 ### end ###

--- a/server/local/studentdashboard-QA.yml
+++ b/server/local/studentdashboard-QA.yml
@@ -19,10 +19,6 @@ authn_wait_min: 0.01
 authn_wait_max: 0.03
 # public members of this MCommunity group have administrative privileges on Latte.
 latte_admin_group: TL-Latte-admin-test
-# These values are used to run a check query on the Latte ESB connection.  The uniqname
-# should be a test user.
-check_uniqname: ststvii
-check_termid: 2060
 # set logging level.  Default is INFO.
 use_log_level: INFO
 ### end ###

--- a/server/local/studentdashboard.yml.TXT
+++ b/server/local/studentdashboard.yml.TXT
@@ -19,10 +19,6 @@ authn_wait_min: 0.01
 authn_wait_max: 0.03
 # public members of this MCommunity group have administrative privileges on Latte.
 latte_admin_group: TL-Latte-admin-test
-# These values are used to run a check query on the Latte ESB connection.  The uniqname
-# should be a test user.
-check_uniqname: ststvii
-check_termid: 2060
 #
 # Set logging level.  Default is INFO.
 use_log_level: DEBUG
@@ -78,10 +74,6 @@ use_log_level: DEBUG
 
 #latte_admin_group: TL-Latte-admin-test
 #latte_admin_group: ctsupportstaff
-
-## values for running the check query against ESB
-check_uniqname: ststvii
-check_termid: 2060
 
 ######### Data provider selection ###########
 ## Two data provider implementations are supplied:


### PR DESCRIPTION
Latte uses an existing user to perform a systems operations check.  This information should only be available in the security.yml file to ensure privacy.