### PR TITLE
TLPORTAL-448: fix issue not finding multiple background image files

### DIFF
--- a/server/external_resources_file.rb
+++ b/server/external_resources_file.rb
@@ -61,7 +61,7 @@ class ExternalResourcesFile
 
   private
   def getExternalResource(directory, file_name)
-    file_name.nil? ? getDirList(directory) : getFile("#{directory}/#{file_name}")
+    (file_name.nil? || file_name.length == 0) ? getDirList(directory) : getFile("#{directory}/#{file_name}")
   end
 
 end

--- a/server/spec/test_external_resources_file.rb
+++ b/server/spec/test_external_resources_file.rb
@@ -38,13 +38,28 @@ class TestExternalResourcesFile < Minitest::Test
     assert_equal @erf.resources_base_directory, @resources_dir, "set external resources directory name correctly"
   end
 
-  def test_list_resources_top
+  def test_list_resources_top_nil
     parsed_file_list = JSON.parse(@erf.get_resource nil)
+    assert_equal 2,parsed_file_list.length,"list resources in top level directory"
+  end
+
+  def test_list_resources_top_empty_string
+    parsed_file_list = JSON.parse(@erf.get_resource "")
     assert_equal 2,parsed_file_list.length,"list resources in top level directory"
   end
 
   def test_list_resources_images
     parsed_file_list = JSON.parse(@erf.get_resource "image")
+    assert_equal 8,parsed_file_list.length,"list resources in images directory"
+  end
+
+  def test_list_resources_images_nil_file_name
+    parsed_file_list = JSON.parse(@erf.get_resource "image", nil)
+    assert_equal 8,parsed_file_list.length,"list resources in images directory"
+  end
+
+  def test_list_resources_images_empty_file_name
+    parsed_file_list = JSON.parse(@erf.get_resource "image", "")
     assert_equal 8,parsed_file_list.length,"list resources in images directory"
   end
 


### PR DESCRIPTION
This is a minimal fix for just this issue since it is the only instance found.  Other situations where the problem might occur will be addressed in JIRA-451 for Dash 2.2.