### PR TITLE
TLPORTAL-465: fix to add correct image directory to war file

### DIFF
--- a/config/warble.rb
+++ b/config/warble.rb
@@ -12,7 +12,7 @@ Warbler::Config.new do |config|
 
   # Application directories to be included in the webapp.
 #  # config.dirs = %w(app config db lib log script vendor tmp)
-  config.dirs = %w(server/config server/local server/log server/public server/test-files UI)
+  config.dirs = %w(server/config server/local server/log server/public server/resources UI)
 
   # Additional files/directories to include, above those in config.dirs
   # config.includes = FileList["db"]


### PR DESCRIPTION
Remove test-files directory from war and use non-test resources directory for image.